### PR TITLE
Bootstrap has changed to "table-striped"

### DIFF
--- a/src/Bootstrap/Html.elm
+++ b/src/Bootstrap/Html.elm
@@ -420,7 +420,7 @@ tableStriped_ = tableBodyStriped' ""
 {-| A table with striped `tbody`s instead of rows. See [Can we have multiple &lt;tbody&gt; in same &lt;table&gt;?](http://stackoverflow.com/questions/3076708/can-we-have-multiple-tbody-in-same-table)
 -}
 tableBodyStriped' : ClassString -> List Html -> Html
-tableBodyStriped' c = table' {class = "table table-body-striped " ++ c}
+tableBodyStriped' c = table' {class = "table table-striped " ++ c}
 
 {-|
     import Html exposing (text)


### PR DESCRIPTION
Judging by the current docs: http://getbootstrap.com/css/#tables-striped it looks like Bootstrap changed their CSS selector.
