### PR TITLE
Remove mention of skipNavigation' which did not exist I think

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.3.1",
+    "version": "6.3.2",
     "summary": "Html shorthand for Bootstrap",
     "repository": "https://github.com/circuithub/elm-bootstrap-html.git",
     "license": "MIT",

--- a/src/Bootstrap/Html.elm
+++ b/src/Bootstrap/Html.elm
@@ -1,4 +1,5 @@
 module Bootstrap.Html where
+
 {-| Shorthand for Bootstrap Html.
 
 # Conventions
@@ -98,7 +99,7 @@ One major difference is that idiomatic elements such as `panelDefault'` are freq
 * Showing and hiding content
 * Screen reader and keyboard navigation content
 * Image replacement
-@docs skipNavigation', skipNavigation_
+@docs skipNavigation_
 
 ## Responsive utilities
 * Available classes


### PR DESCRIPTION
and bump the package. The library looks really useful to me and I wanted to bring the newest version to the package repository. There's a conflict on one function not being published, which did not show up when I did elm package diff, so I think it didn't exist. before.
